### PR TITLE
Don't list S3 object if no files added in recording

### DIFF
--- a/recording/CHANGELOG.md
+++ b/recording/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Synchronize tracks based on RTCP sender reports [#393](https://github.com/fishjam-dev/membrane_rtc_engine/pull/393)
 * Fix setting last buffer timestamp [#394](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/394)
 * Fix rtcp synchronization [#397](https://github.com/fishjam-dev/membrane_rtc_engine/pull/397)
-* Don't list S3 object if no files added in recording [#396](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/396)
+* Don't list S3 object if no files added in recording [#396](https://github.com/fishjam-dev/membrane_rtc_engine/pull/396)
 
 ## 0.1.0
 * Initial release [#356](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/356)

--- a/recording/CHANGELOG.md
+++ b/recording/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Synchronize tracks based on RTCP sender reports [#393](https://github.com/fishjam-dev/membrane_rtc_engine/pull/393)
 * Fix setting last buffer timestamp [#394](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/394)
 * Fix rtcp synchronization [#397](https://github.com/fishjam-dev/membrane_rtc_engine/pull/397)
+* Don't list S3 object if no files added in recording [#396](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/396)
 
 ## 0.1.0
 * Initial release [#356](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/356)

--- a/recording/lib/guard.ex
+++ b/recording/lib/guard.ex
@@ -20,8 +20,10 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Guard do
   defp close_stores({file_storage, file_opts}, stores, recording_id) do
     files = file_storage.list_files(file_opts)
 
-    Enum.filter(stores, fn {module, opts} ->
-      module.on_close(files, recording_id, opts) == :ok
-    end)
+    if map_size(files) > 0 do
+      Enum.filter(stores, fn {module, opts} ->
+        module.on_close(files, recording_id, opts) == :ok
+      end)
+    end
   end
 end

--- a/recording/lib/guard.ex
+++ b/recording/lib/guard.ex
@@ -24,6 +24,8 @@ defmodule Membrane.RTC.Engine.Endpoint.Recording.Guard do
       Enum.filter(stores, fn {module, opts} ->
         module.on_close(files, recording_id, opts) == :ok
       end)
+    else
+      stores
     end
   end
 end

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.0-dev
 * Add RTCP sender reports [#393](https://github.com/fishjam-dev/membrane_rtc_engine/pull/393)
 * Allow for muting a track without renegotiation [#392](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/392)
+* RTP connection allocator is started without link [#396](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/396) 
 
 ## 0.8.0
 * Update deps [#374](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/374)

--- a/webrtc/CHANGELOG.md
+++ b/webrtc/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.9.0-dev
 * Add RTCP sender reports [#393](https://github.com/fishjam-dev/membrane_rtc_engine/pull/393)
 * Allow for muting a track without renegotiation [#392](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/392)
-* RTP connection allocator is started without link [#396](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/396) 
+* RTP connection allocator is started without link [#396](https://github.com/fishjam-dev/membrane_rtc_engine/pull/396) 
 
 ## 0.8.0
 * Update deps [#374](https://github.com/jellyfish-dev/membrane_rtc_engine/pull/374)

--- a/webrtc/lib/webrtc/rtp_connection_allocator.ex
+++ b/webrtc/lib/webrtc/rtp_connection_allocator.ex
@@ -73,7 +73,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
   @padding_packet_size 8 * 256
 
   @impl true
-  def create(), do: GenServer.start_link(__MODULE__, [], [])
+  def create(), do: GenServer.start(__MODULE__, [], [])
 
   @impl true
   def destroy(pid), do: GenServer.stop(pid)


### PR DESCRIPTION
Changes:
- Don't list S3 object if no files added in Recording endpoint
- RTP connection allocator is started without link in WebRTC endpoint